### PR TITLE
Update Java dependency for NodeJS v6 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/mbejda/Nodejs-Stanford-Classifier#readme",
   "dependencies": {
-    "java": "0.6.0",
+    "java": "0.7.2",
     "properties-reader": "0.0.15"
   },
   "devDependencies": {"jasmine":"2.4.1"}


### PR DESCRIPTION
Thanks for a great module!

This PR upgrades the Java dependency to support NodeJS v6.

The last test is failing though (with or without this upgrade) because it's trying to access a `20newsgroups4.ser.gz` file which does not exist in the repo...
