### PR TITLE
Fix styling in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ tolerance=1e-4
 
 other options that can be used are [here](http://nlp.stanford.edu/nlp/javadoc/javanlp/edu/stanford/nlp/classify/ColumnDataClassifier.html "stanford classifer").
 
-<hr>
+
 ## Resources
 **NPM Repository :**<br>
 [https://www.npmjs.com/package/stanford-classifier](https://www.npmjs.com/package/stanford-classifier)
@@ -153,12 +153,7 @@ other options that can be used are [here](http://nlp.stanford.edu/nlp/javadoc/ja
 [http://www.mbejda.com/using-the-stanford-classifier-with-node/](http://www.mbejda.com/using-the-stanford-classifier-with-node/)
 
 
-<br>
-If you need any help, send me a tweet on twitter<br>
+If you need any help, send me a tweet on twitter
 [@notmilobejda](https://twitter.com/notmilobejda).
-<br>
-![NPM](https://nodei.co/npm/stanford-classifier.png)(https://nodei.co/npm/stanford-classifier/)
 
-
-
-
+[![NPM](https://nodei.co/npm/stanford-classifier.png)](https://www.npmjs.com/package/stanford-classifier)

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The classifier needs to be trained with pre-trained data. Without trained data, 
 The `train()` method is used to train the `stanford-classifier` with a pre-trained dataset. Here is an example of how to use the `train()` method to train the `stanford-classifier`.
 
 *Example :*
-```
+```js
 /// Dependencies
 var stanfordClassifier = require('stanford-classifier');
 var byline = require('byline');
@@ -149,7 +149,7 @@ other options that can be used are [here](http://nlp.stanford.edu/nlp/javadoc/ja
 **Dataset:**<br>
 [https://gist.github.com/mbejda/e57d29c887cbda0b5a8f#file-band-or-organization](https://gist.github.com/mbejda/e57d29c887cbda0b5a8f#file-band-or-organization)<br>
 
-**Blog :**<br>
+**Blog:**<br>
 [http://www.mbejda.com/using-the-stanford-classifier-with-node/](http://www.mbejda.com/using-the-stanford-classifier-with-node/)
 
 


### PR DESCRIPTION
In the footer, the styling was getting messed up by an uneeded `<hr>` tag, and then the text below it was fixed by removing the `<br>`s. Also, updated the NPM image to the later syntax.